### PR TITLE
make boxes for temporary highlighted words for easy differentiation

### DIFF
--- a/HighlightWords.py
+++ b/HighlightWords.py
@@ -77,7 +77,8 @@ class HighlightWordsCommand(sublime_plugin.WindowCommand):
 				continue
 			word_set.add(word)
 			regions = view.find_all(word, flag)
-			view.add_regions('highlight_word_%d' % size, regions,  SCOPES[size % len(SCOPES)] , '', sublime.HIDE_ON_MINIMAP)
+			# view.add_regions('highlight_word_%d' % size, regions,  SCOPES[size % len(SCOPES)] , '', sublime.HIDE_ON_MINIMAP)
+			view.add_regions('highlight_word_%d' % size, regions,  SCOPES[size % len(SCOPES)] , '', sublime.DRAW_NO_FILL)
 			size += 1
 		view.settings().set('highlight_size', size)
 		view.settings().set('highlight_text', text)


### PR DESCRIPTION
made changes to make boxes around matched temporary highlighted words instead of changing background area colour. This will differentiate between temporary and permanently highlighted words.
Please view the attached screenshot once : 
![capture](https://user-images.githubusercontent.com/2693023/47405340-bc47da00-d76e-11e8-9cc5-b440024bfa5b.PNG).